### PR TITLE
fix/update progress logic of both queues

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -7,11 +7,12 @@ import BookMdl from "../src/models/book.js";
 import helper from "../src/utils/helper.js";
 
 let booksArr = [];
-let processedRows = 1;
 const importWorker = new Worker(
   "importBooksQueue",
 
   async (job) => {
+    let processedRows = 0;
+    let lastReportedProgress = 0;
     fs.createReadStream(job.data.filePath)
       .pipe(csv.parse({ headers: true }))
       .on("data", async (data) => {
@@ -22,8 +23,15 @@ const importWorker = new Worker(
         data.lastUpdated = helper.currentDateAndTime();
 
         booksArr.push(data);
-        let progress = Math.round((processedRows / job.data.totalRows) * 100);
-        await job.updateProgress(progress);
+        const currentProgress = Math.round(
+          (processedRows / job.data.totalRows) * 100
+        );
+        const roundedProgress = Math.ceil(currentProgress / 10) * 10; // Rounds up to the next multiple of 10
+
+        if (roundedProgress > lastReportedProgress && roundedProgress <= 100) {
+          lastReportedProgress = roundedProgress;
+          await job.updateProgress(roundedProgress);
+        }
       })
       .on("error", (err) => {
         throw new Error(err);
@@ -49,6 +57,9 @@ const exportWoker = new Worker(
   "exportBooksQueue",
 
   async (job) => {
+    let processedRows = 0;
+    let lastReportedProgress = 0;
+
     const allBooks = await BookMdl.find();
     const csvStream = csv.format({ headers: true });
     const fileStream = fs.createWriteStream(job.data.filePath);
@@ -56,7 +67,8 @@ const exportWoker = new Worker(
     csvStream.pipe(fileStream);
 
     if (allBooks.length > 0) {
-      allBooks.forEach((book) => {
+      allBooks.forEach(async (book) => {
+        processedRows++;
         csvStream.write({
           ISBN: book.ISBN,
           title: book.title,
@@ -69,6 +81,16 @@ const exportWoker = new Worker(
           addedAt: book.addedAt.toLocaleString(),
           lastUpdated: book.lastUpdated.toLocaleString(),
         });
+
+        const currentProgress = Math.round(
+          (processedRows / allBooks.length) * 100
+        );
+        const roundedProgress = Math.ceil(currentProgress / 10) * 10; // Rounds up to the next multiple of 10
+
+        if (roundedProgress > lastReportedProgress && roundedProgress <= 100) {
+          lastReportedProgress = roundedProgress;
+          await job.updateProgress(roundedProgress);
+        }
       });
     }
     csvStream.end();

--- a/src/components/book/book.service.js
+++ b/src/components/book/book.service.js
@@ -278,7 +278,7 @@ const importCSV = async (file) => {
                   column: `ISBN`,
                   error: `ISBN is required`,
                 });
-              } else if (!/^(97[89])(-\d{1,5}){4}$/.test(data.ISBN)) {
+              } else if (!/^(?:97[89])(?:-[0-9]{1,5}){3}-[0-9]$/.test(data.ISBN)) {
                 errors.push({
                   row: currentRowNumber,
                   column: `ISBN`,


### PR DESCRIPTION
- update progress in round of next multiple of 10 to shorter progress and when rounded progress is greater then last progress only then update progress for stop overloading on updating progress every time
- and also fix ISBN validation regex in import functionality for only accept 13 digit long isbn with 4 hyphen